### PR TITLE
fix: take search into account for (#82)

### DIFF
--- a/src/lib/components/NavigationConfirm.tsx
+++ b/src/lib/components/NavigationConfirm.tsx
@@ -124,7 +124,7 @@ class NavigationConfirm extends React.Component<IProps, IState> {
     private onCancel = () => this.setState({ isOpen: false });
     private open = () => this.setState({ isOpen: true });
 
-    private isTheSameLocation = (nextLocation: Location): boolean => nextLocation.pathname === this.props.location.pathname;
+    private isTheSameLocation = (nextLocation: Location): boolean => nextLocation.pathname === this.props.location.pathname && nextLocation.search === this.props.location.search;
     private shouldBlock = (nextLocation: Location): boolean => this.state.isActive && this.shouldShow() && !this.isTheSameLocation(nextLocation);
     private shouldShow = (): boolean => {
         const { when, location, history, match } = this.props;


### PR DESCRIPTION
There is a problem when only the `search` is changed, the `isTheSameLocation` returns `false`, thus missing blocking the navigation.

This fix adds the `location.search` into the decision if the location has changed.